### PR TITLE
feat: reduce image size

### DIFF
--- a/dagger/cd.go
+++ b/dagger/cd.go
@@ -16,7 +16,7 @@ func (m *Kv2) buildServer(
 	return m.devEnv(ctx, source, nil).
 		WithWorkdir("cmd/server").
 		WithEnvVariable("CGO_ENABLED", "0").
-		WithExec([]string{"go", "build", "-o", "/app/server", "."}).
+		WithExec([]string{"go", "build", "-ldflags", "-s -w", "-gcflags=all=-l -C", "-o", "/app/server", "."}).
 		File("/app/server")
 }
 

--- a/dagger/cd.go
+++ b/dagger/cd.go
@@ -30,7 +30,6 @@ func (m *Kv2) BuildServerContainer(
 	return dag.Container().
 		From("gcr.io/distroless/static-debian12").
 		WithAnnotation("org.opencontainers.image.title", "kv2").
-		WithAnnotation("org.opencontainers.image.description", "Encrypted secrets management for the homelab.").
 		WithAnnotation("org.opencontainers.image.created", time.Now().String()).
 		WithAnnotation("org.opencontainers.image.source", "https://github.com/hugginsio/kv2").
 		WithAnnotation("org.opencontainers.image.licenses", "BSD-3-Clause").

--- a/dagger/forge.go
+++ b/dagger/forge.go
@@ -5,8 +5,6 @@ import (
 	"dagger/kv-2/internal/dagger"
 	"fmt"
 	"strings"
-
-	"github.com/google/uuid"
 )
 
 // Run all pull request checks.
@@ -42,14 +40,8 @@ func (m *Kv2) Release(
 ) (string, error) {
 	source := dag.Git("https://github.com/hugginsio/kv2.git", dagger.GitOpts{KeepGitDir: true}).Tag(tag).Tree()
 	serverContainer := m.BuildServerContainer(ctx, source).
-		WithLabel("org.opencontainers.image.version", tag)
-
-	if registry == "ttl.sh" {
-		imageName = uuid.NewString()
-		tag = "30m"
-	} else {
-		serverContainer = serverContainer.WithRegistryAuth(registry, username, password)
-	}
+		WithLabel("org.opencontainers.image.version", tag).
+		WithRegistryAuth(registry, username, password)
 
 	if _, err := serverContainer.Publish(ctx, fmt.Sprintf("%s/%s:%s", registry, imageName, tag)); err != nil {
 		return "", err


### PR DESCRIPTION
This change introduces some build flags that reduce the binary (and by extension, the container image) size.

- `"-ldflags", "-s -w"`: disable symbol table and DWARF generation
- `"-gcflags=all=-l -C"`: disable function inlining & error message column printing