### PR TITLE
fix(cli): release behavior

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: dagger/dagger-for-github@e47aba410ef9bb9ed81a4d2a97df31061e5e842e # 8.0.0
         with:
           verb: call
-          args: "release --tag=$TAG --registry=ghcr.io --image-name=$IMAGE_NAME --username=$REGISTRY_USERNAME --password=env://REGISTRY_PASSWORD"
+          args: "release-server --tag=$TAG --registry=ghcr.io --image-name=$IMAGE_NAME --username=$REGISTRY_USERNAME --password=env://REGISTRY_PASSWORD"
         env:
           IMAGE_NAME: ${{ github.repository }}
           REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
       - uses: dagger/dagger-for-github@e47aba410ef9bb9ed81a4d2a97df31061e5e842e # 8.0.0
         with:
           verb: call
-          args: "build-cli --tag=$TAG --token=env://REGISTRY_PASSWORD"
+          args: "release-cli --tag=$TAG --token=env://TOKEN"
         env:
           TAG: ${{ github.event.release.tag_name }}
           TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dagger/cd.go
+++ b/dagger/cd.go
@@ -39,7 +39,7 @@ func (m *Kv2) BuildServerContainer(
 		WithExposedPort(80) // used for development mode ONLY
 }
 
-func (m *Kv2) BuildCli(
+func (m *Kv2) ReleaseCli(
 	ctx context.Context,
 	tag string,
 	// +optional
@@ -54,6 +54,6 @@ func (m *Kv2) BuildCli(
 		WithEnvVariable("GOCACHE", "/go/build-cache").
 		WithDirectory("/go/src/github.com/hugginsio/kv2/", source).
 		WithWorkdir("/go/src/github.com/hugginsio/kv2/").
-		WithExec([]string{"goreleaser", "build"}).
+		WithExec([]string{"goreleaser", "release"}).
 		Stdout(ctx)
 }

--- a/dagger/forge.go
+++ b/dagger/forge.go
@@ -26,7 +26,7 @@ func (m *Kv2) PullRequest(
 	return strings.Join([]string{lint, test}, "\n"), nil
 }
 
-func (m *Kv2) Release(
+func (m *Kv2) ReleaseServer(
 	ctx context.Context,
 	tag string,
 	registry string,


### PR DESCRIPTION
This change should make the CLI build & release job actually upload the artifacts to the release and update the Homebrew tap.